### PR TITLE
CI: Add release workflow for Linux, macOS, and Windows binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,112 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install PyInstaller
+        run: pip install pyinstaller
+
+      - name: Build Executable
+        run: pyinstaller --onefile -n antigravity-conversation-fix rebuild_conversations.py
+
+      - name: Prepare Linux DEB
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          mkdir -p package/DEBIAN
+          mkdir -p package/usr/bin
+          cp dist/antigravity-conversation-fix package/usr/bin/
+          
+          VERSION="${GITHUB_REF_NAME#v}"
+          if [[ ! "$VERSION" =~ ^[0-9] ]]; then
+            VERSION="1.0.0"
+          fi
+          
+          cat <<EOF > package/DEBIAN/control
+          Package: antigravity-conversation-fix
+          Version: $VERSION
+          Architecture: amd64
+          Maintainer: FutureisinPast
+          Description: Rebuilds the Antigravity conversation index.
+          EOF
+          
+          dpkg-deb --build package
+          mv package.deb antigravity-conversation-fix-ubuntu-amd64.deb
+
+      - name: Rename Binaries
+        shell: bash
+        run: |
+          if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
+            mv dist/antigravity-conversation-fix antigravity-conversation-fix-linux-amd64
+          elif [ "${{ matrix.os }}" = "macos-latest" ]; then
+            mv dist/antigravity-conversation-fix antigravity-conversation-fix-macos-x64
+          elif [ "${{ matrix.os }}" = "windows-latest" ]; then
+            mv dist/antigravity-conversation-fix.exe antigravity-conversation-fix-windows-x64.exe
+          fi
+
+      - name: Upload Artifacts (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: binary-linux
+          path: |
+            antigravity-conversation-fix-linux-amd64
+            antigravity-conversation-fix-ubuntu-amd64.deb
+
+      - name: Upload Artifacts (macOS)
+        if: matrix.os == 'macos-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: binary-macos
+          path: antigravity-conversation-fix-macos-x64
+
+      - name: Upload Artifacts (Windows)
+        if: matrix.os == 'windows-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: binary-windows
+          path: antigravity-conversation-fix-windows-x64.exe
+
+  release:
+    name: Create GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    # Only automatically publish a release if a tag was pushed.
+    # Otherwise, it just runs the build steps above for workflow_dispatch.
+    if: startsWith(github.ref, 'refs/tags/v')
+    
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-assets
+          merge-multiple: true
+          
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: release-assets/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Sets up a PyInstaller-based GitHub Action to automatically build and release `rebuild_conversations.py` as a standalone executable for Ubuntu (including `.deb` package), macOS, and Windows.


* **New Features**
  * Added automated builds for Linux, macOS, and Windows.
  * Linux releases now include a Debian package.
  * Version-tagged releases are automatically published with platform-specific downloadable files.
  * Added manual release workflow support.

Closes : #39 
